### PR TITLE
gh-action: use -Zrustdoc-map for building docs

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
       - name: Create Docs
-        run: cargo doc --workspace --verbose --all-features --no-deps -Zunstable-options -Zrustdoc-scrape-examples
+        # rustdoc-map allows us to link to doc.rs for dependencies
+        run: cargo doc --workspace --verbose --all-features --no-deps -Zunstable-options -Zrustdoc-scrape-examples -Zrustdoc-map
       - name: Fix permissions
         run: |
           chmod -c -R +rX "target/doc/" | while read line; do


### PR DESCRIPTION
This allows docs build for main with --no-deps to
still link to other crates.