### PR TITLE
fix(cryprot-core)!: set is_nightly cfg in build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_core 0.9.5",
  "rayon",
+ "rustc_version",
  "seq-macro",
  "serde",
  "subtle",

--- a/cryprot-core/Cargo.toml
+++ b/cryprot-core/Cargo.toml
@@ -17,7 +17,6 @@ bench = false
 
 [features]
 __testing = ["dep:tracing-subscriber"]
-nightly = []
 num-traits = ["dep:num-traits"]
 tokio-rayon = ["dep:rayon", "dep:tokio"]
 
@@ -47,6 +46,9 @@ libc = { workspace = true }
 [dev-dependencies]
 criterion.workspace = true
 proptest = "1.6.0"
+
+[build-dependencies]
+rustc_version = "0.4.1"
 
 [[bench]]
 harness = false

--- a/cryprot-core/build.rs
+++ b/cryprot-core/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(is_nightly)");
+
+    let is_nightly = rustc_version::version_meta()
+        .map(|meta| meta.channel == rustc_version::Channel::Nightly)
+        .unwrap_or(false);
+
+    if is_nightly {
+        println!("cargo:rustc-cfg=is_nightly");
+    }
+}

--- a/cryprot-core/src/block/gf128.rs
+++ b/cryprot-core/src/block/gf128.rs
@@ -218,7 +218,7 @@ mod clmul {
         }
     }
 
-    #[cfg(all(test, feature = "nightly", target_feature = "pclmulqdq"))]
+    #[cfg(all(is_nightly, test, target_feature = "pclmulqdq"))]
     mod benches {
         extern crate test;
 
@@ -439,7 +439,7 @@ mod scalar {
         }
     }
 
-    #[cfg(all(test, feature = "nightly"))]
+    #[cfg(all(is_nightly, test))]
     mod benches {
         extern crate test;
 

--- a/cryprot-core/src/lib.rs
+++ b/cryprot-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(test))]
+#![cfg_attr(is_nightly, feature(test))]
 //! Core utilites for cryptographic protocols.
 //!
 //! This crate implements several core utilities for cryptographic protocols.


### PR DESCRIPTION
Removes the `nightly` feature which was just used for the unstable benchmarking API and instead sets a cfg in a build.rs script.

The main benefit is that we can now use --all-features again with a stable compiler.